### PR TITLE
s/ownable2Step/ownable

### DIFF
--- a/src/base/ChainSettlers.sol
+++ b/src/base/ChainSettlers.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {Ownable2Step, Ownable} from "@openzeppelin/access/Ownable2Step.sol";
+import {Ownable} from "@openzeppelin/access/Ownable.sol";
 
 /// @title ChainSettlers
 /// @notice Contract for managing chain settlers
-contract ChainSettlers is Ownable2Step {
+contract ChainSettlers is Ownable {
     /// @notice Error thrown when the chain settler params length mismatch
     error ChainSettlersParamsLengthMismatch();
     /// @notice Error thrown when the chain settler is not supported

--- a/src/base/ProtocolFees.sol
+++ b/src/base/ProtocolFees.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {Ownable2Step, Ownable} from "@openzeppelin/access/Ownable2Step.sol";
+import {Ownable} from "@openzeppelin/access/Ownable.sol";
 
 /// @title ProtocolFees
 /// @notice Contract for managing protocol fees
-contract ProtocolFees is Ownable2Step {
+contract ProtocolFees is Ownable {
     /// @notice Error thrown when the protocol share bps is invalid
     error InvalidProtocolShareBps(uint16 protocolShareBps);
     /// @notice Error thrown when the protocol share of sender fee pct is invalid


### PR DESCRIPTION
Given the number of contracts deployed, it's a lot of work to manually transition them over to a multisig SAFE (which is the right way to "own" these contracts). So, substituting `ownable2step` for `ownable`.