### PR TITLE
make settlementCache public

### DIFF
--- a/src/base/Settler.sol
+++ b/src/base/Settler.sol
@@ -32,7 +32,7 @@ abstract contract Settler is ISettler, ProtocolFees, ReentrancyGuard {
     uint256 internal constant UNIT_IN_MILLI_BASIS_POINTS = 10_000_000;
 
     /// @notice Mapping of migration ID to settlement cach
-    mapping(bytes32 => SettlementCache) internal settlementCaches;
+    mapping(bytes32 => SettlementCache) public settlementCaches;
 
     /// @notice Constructor for the Settler contract
     /// @param initialOwner The initial owner of the contract


### PR DESCRIPTION
Current `withdraw(bytes32 migrationId)` function can't be easily used off-chain to check if a `migrationId` is stored in a settler. This change will allow us to use the auto-generated getter.